### PR TITLE
Multiple bug fixes

### DIFF
--- a/include/boost/sqlite/iterator.hpp
+++ b/include/boost/sqlite/iterator.hpp
@@ -38,10 +38,15 @@ namespace detail
 
     inline void convert_field(sqlite_int64 & target, const field & f) {target = f.get_int();}
 
-    template<typename = std::enable_if_t<!std::is_same<std::int64_t, sqlite_int64>::value>>
-    inline void convert_field(std::int64_t & target, const field & f)
+    // Overload for std::int64_t only when it differs from sqlite_int64
+    template<typename Int64 = std::int64_t>
+    inline typename std::enable_if<
+        !std::is_same<Int64, sqlite_int64>::value && std::is_same<Int64, std::int64_t>::value,
+        void
+    >::type
+    convert_field(Int64 & target, const field & f)
     {
-        target = static_cast<std::int64_t>(f.get_int());
+        target = static_cast<Int64>(f.get_int());
     }
 
     inline void convert_field(double & target, const field & f) {target = f.get_double();}
@@ -89,8 +94,13 @@ namespace detail
 
     inline value_type required_field_type(const sqlite3_int64 &) {return value_type::integer;}
 
-    template<typename = std::enable_if_t<!std::is_same<std::int64_t, sqlite_int64>::value>>
-    inline value_type required_field_type(const std::int64_t &) {return value_type::integer;}
+    // Overload for std::int64_t only when it differs from sqlite_int64
+    template<typename Int64 = std::int64_t>
+    inline typename std::enable_if<
+        !std::is_same<Int64, sqlite_int64>::value && std::is_same<Int64, std::int64_t>::value,
+        value_type
+    >::type
+    required_field_type(const Int64 &) {return value_type::integer;}
 
     template<typename Allocator, typename Traits>
     inline value_type required_field_type(const std::basic_string<char, Allocator, Traits> & )

--- a/include/boost/sqlite/statement.hpp
+++ b/include/boost/sqlite/statement.hpp
@@ -82,22 +82,24 @@ struct param_ref
     /// Bind pointer value to the parameter. @see https://www.sqlite.org/bindptr.html
     template<typename T>
     param_ref(std::unique_ptr<T> ptr)
-                    : impl_(variant2::in_place_index_t<7>{},
-                            std::unique_ptr<void, void(*)(void*)>(
-                                static_cast<void*>(ptr.release()),
-                                +[](void * ptr){delete static_cast<T*>(ptr);}),
-                                typeid(T).name())
+                    : impl_(variant2::in_place_index_t<8>{},
+                            std::make_pair(
+                                std::unique_ptr<void, void(*)(void*)>(
+                                    static_cast<void*>(ptr.release()),
+                                    +[](void * ptr){delete static_cast<T*>(ptr);}),
+                                typeid(T).name()))
     {
     }
 
     /// Bind pointer value with a function as deleter to the parameter. @see https://www.sqlite.org/bindptr.html
     template<typename T>
     param_ref(std::unique_ptr<T, void(*)(T*)> ptr)
-                    : impl_(variant2::in_place_index_t<7>{},
-                            std::unique_ptr<void, void(*)(void*)>(
-                                static_cast<void*>(ptr.release()),
-                                +[](void * ptr){delete static_cast<T*>(ptr);}),
-                             typeid(T).name())
+                    : impl_(variant2::in_place_index_t<8>{},
+                            std::make_pair(
+                                std::unique_ptr<void, void(*)(void*)>(
+                                    static_cast<void*>(ptr.release()),
+                                    +[](void * ptr){delete static_cast<T*>(ptr);}),
+                                typeid(T).name()))
     {
     }
 
@@ -107,11 +109,12 @@ struct param_ref
     param_ref(std::unique_ptr<T, Deleter> ptr,
               typename std::enable_if<std::is_empty<Deleter>::value &&
                                std::is_default_constructible<Deleter>::value, int>::type * = nullptr)
-                    : impl_(variant2::in_place_index_t<7>{},
-                            std::unique_ptr<void, void(*)(void*)>(
-                                static_cast<void*>(ptr.release()),
-                                +[](void * ptr){delete static_cast<T*>(ptr);}),
-                            typeid(T).name())
+                    : impl_(variant2::in_place_index_t<8>{},
+                            std::make_pair(
+                                std::unique_ptr<void, void(*)(void*)>(
+                                    static_cast<void*>(ptr.release()),
+                                    +[](void * ptr){delete static_cast<T*>(ptr);}),
+                                typeid(T).name()))
     {
     }
 #endif

--- a/include/boost/sqlite/statement.hpp
+++ b/include/boost/sqlite/statement.hpp
@@ -268,7 +268,7 @@ struct statement
     {
       BOOST_SQLITE_ASSIGN_EC(ec, cc);
       ei.set_message(sqlite3_errmsg(sqlite3_db_handle(impl_.get())));
-      }
+    }
     return !done_;
   }
 
@@ -366,6 +366,7 @@ struct statement
       system::error_code& ec,
       error_info& info)
     {
+      done_ = false;
       bind(std::forward<ArgRange>(params), ec, info);
       while (!ec && !done())
         step(ec, info);
@@ -390,6 +391,7 @@ struct statement
       system::error_code& ec,
       error_info& info)
     {
+      done_ = false;
       bind(std::move(params), ec, info);
       while (!ec && !done())
         step(ec, info);


### PR DESCRIPTION
Fix a couple places where enable_if was wrong and tripped up on Android builds.

Reset done_ before execute() so reuse of the same prepared statement function properly.

Fix dangling reference in param_ref when binding temporary strings
Previously, when binding temporary string-like objects (e.g., the result
of to_string(uuid)), param_ref would construct a string_view that
referenced the temporary. Once the temporary was destroyed, this created
a dangling reference.